### PR TITLE
Remove zero-pad from run number

### DIFF
--- a/bidskit/translate.py
+++ b/bidskit/translate.py
@@ -546,14 +546,14 @@ def add_run_number(bids_suffix, run_no):
 
         if '_' in bids_suffix:
 
-            # Add '_run-xx' before final suffix
+            # Add '_run-x' before final suffix
             bmain, bseq = bids_suffix.rsplit('_', 1)
-            new_bids_suffix = '%s_run-%02d_%s' % (bmain, run_no, bseq)
+            new_bids_suffix = '%s_run-%d_%s' % (bmain, run_no, bseq)
 
         else:
 
-            # Isolated final suffix - just add 'run-xx_' as a prefix
-            new_bids_suffix = 'run-%02d_%s' % (run_no, bids_suffix)
+            # Isolated final suffix - just add 'run-x_' as a prefix
+            new_bids_suffix = 'run-%d_%s' % (run_no, bids_suffix)
 
     return new_bids_suffix
 


### PR DESCRIPTION
According to the BIDS specification, the run number should be an <index>, hence not zero-padded.

"If more than one run of the same task has been acquired the run-<index> key/value pair MUST be used: _run-1, _run-2, _run-3, and so on."
(https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#task-including-resting-state-imaging-data)